### PR TITLE
Fix bug in useChat hook

### DIFF
--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -33,7 +33,10 @@ export function useChat(): UseChatReturn {
     setIsTyping(true);
 
     const assistantReply = await callApi(history);
-    setMessages(prev => [...prev, { role: 'assistant', content: assistantReply }]);
+    setMessages((prev: ChatMessage[]) => [
+      ...prev,
+      { role: 'assistant', content: assistantReply },
+    ]);
     setIsTyping(false);
   };
 


### PR DESCRIPTION
## Summary
- correctly type the `prev` argument in `useChat` state update

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'next/server' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6841de5abea4832fbd79a20efff326f9