### PR TITLE
Fix auto scroll ref type

### DIFF
--- a/src/hooks/useAutoScroll.ts
+++ b/src/hooks/useAutoScroll.ts
@@ -12,7 +12,7 @@ import { useEffect, useRef } from "react";
  * <div ref={bottomRef} />
  */
 export function useAutoScroll(dependencies: unknown[]): React.RefObject<HTMLDivElement | null> {
-  const ref = useRef<HTMLDivElement>(null);
+  const ref = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     ref.current?.scrollIntoView({ behavior: "smooth" });


### PR DESCRIPTION
## Summary
- fix `useAutoScroll` hook to explicitly allow null ref

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6841e3d3f0a4832f89587a672a850bca