### PR TITLE
refacto: Add zod validation to chat API

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,26 +1,38 @@
 import { NextRequest, NextResponse } from 'next/server';
-import type { ChatMessage } from '@/types/chat';
+import type { ChatMessage, ChatApiError } from '@/types/chat';
+import { z } from 'zod';
 import { chat } from '@/app/actions/chat';
 
 export async function POST(req: NextRequest) {
-  let messages: ChatMessage[] | undefined;
-  try {
-    const body = (await req.json()) as { messages?: ChatMessage[] };
-    messages = body.messages;
-  } catch (err) {
+  const messageSchema = z.object({
+    role: z.enum(['user', 'assistant', 'system']),
+    content: z.string().min(1),
+  });
+  const bodySchema = z.object({
+    messages: z.array(messageSchema).min(1, 'No messages provided'),
+  });
+
+  const json = await req.json().catch((err) => {
     console.error('Failed to parse request body', err);
-    return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 });
+    const error: ChatApiError = { error: 'Invalid JSON payload' };
+    return NextResponse.json(error, { status: 400 });
+  });
+  if (json instanceof NextResponse) return json;
+
+  const parsed = bodySchema.safeParse(json);
+  if (!parsed.success) {
+    const error: ChatApiError = { error: parsed.error.message };
+    return NextResponse.json(error, { status: 400 });
   }
 
-  if (!messages || !Array.isArray(messages) || messages.length === 0) {
-    return NextResponse.json({ error: 'No messages provided' }, { status: 400 });
-  }
+  const { messages } = parsed.data as { messages: ChatMessage[] };
 
   try {
     const reply = await chat(messages);
     return NextResponse.json({ reply });
   } catch (err: unknown) {
     const error = err as Error;
-    return NextResponse.json({ error: error.message || 'Server error' }, { status: 500 });
+    const resp: ChatApiError = { error: error.message || 'Server error' };
+    return NextResponse.json(resp, { status: 500 });
   }
 }

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -8,4 +8,8 @@ export interface ChatMessage {
 export interface ChatApiResponse {
   reply?: string;
   error?: string;
-} 
+}
+
+export interface ChatApiError {
+  error: string;
+}


### PR DESCRIPTION
## Summary
- validate chat API request body with zod
- add `ChatApiError` type
- use `ChatApiError` when returning errors

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842ec9d7b2c832f99622dafbd36ff29