### PR TITLE
Use env constants for API keys

### DIFF
--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -1,7 +1,4 @@
 import OpenAI from 'openai';
+import { env } from './env';
 
-if (!process.env.OPENAI_API_KEY) {
-  throw new Error('OPENAI_API_KEY is not set');
-}
-
-export const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY }); 
+export const openai = new OpenAI({ apiKey: env.OPENAI_API_KEY });

--- a/src/lib/pinecone.ts
+++ b/src/lib/pinecone.ts
@@ -1,7 +1,4 @@
 import { Pinecone } from '@pinecone-database/pinecone';
+import { env } from './env';
 
-if (!process.env.PINECONE_API_KEY) {
-  throw new Error('PINECONE_API_KEY is not set');
-}
-
-export const pinecone = new Pinecone({ apiKey: process.env.PINECONE_API_KEY }); 
+export const pinecone = new Pinecone({ apiKey: env.PINECONE_API_KEY });


### PR DESCRIPTION
## Summary
- import `env` in OpenAI and Pinecone helpers
- use `env` constants instead of `process.env`
- remove runtime environment checks

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6842ecac3254832f899acb93ffde24bd