### PR TITLE
Move security headers to headers.ts

### DIFF
--- a/src/app/headers.ts
+++ b/src/app/headers.ts
@@ -1,0 +1,9 @@
+export async function headers() {
+  return {
+    'X-Frame-Options': 'DENY',
+    'X-Content-Type-Options': 'nosniff',
+    'Referrer-Policy': 'origin-when-cross-origin',
+    'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
+    'Content-Security-Policy': "default-src 'self'; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline';",
+  } as Record<string, string>;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import "./globals.css";
 import { ThemeProviderWrapper } from "@/providers/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { env } from "@/lib/env";
+import { headers as securityHeaders } from "./headers";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -102,3 +103,5 @@ export default function RootLayout({
     </html>
   );
 }
+
+export { securityHeaders as headers };

--- a/src/middleware.tsx
+++ b/src/middleware.tsx
@@ -15,20 +15,7 @@ export function middleware(request: NextRequest) {
     },
   });
 
-  // Add security headers
-  response.headers.set('X-Frame-Options', 'DENY');
-  response.headers.set('X-Content-Type-Options', 'nosniff');
-  response.headers.set('Referrer-Policy', 'origin-when-cross-origin');
-  response.headers.set(
-    'Permissions-Policy',
-    'camera=(), microphone=(), geolocation=()'
-  );
-
-  // Add CSP header for enhanced security
-  response.headers.set(
-    'Content-Security-Policy',
-    "default-src 'self'; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline';"
-  );
+  // Security headers moved to src/app/headers.ts
 
   return response;
 }


### PR DESCRIPTION
## Summary
- create `src/app/headers.ts` with an async `headers()` function
- remove security headers from middleware
- wire headers into the root layout

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6842ecbee69c832fbfd603d9dd306327